### PR TITLE
Update DashboardWidget.php

### DIFF
--- a/plugin/classes/DashboardWidget.php
+++ b/plugin/classes/DashboardWidget.php
@@ -9,6 +9,8 @@ namespace Palasthotel\FutureMonitor;
  */
 class DashboardWidget {
 
+	public $plugin;
+
 	const ID = "future-posts-monitor";
 
 	public function __construct(Plugin $plugin) {


### PR DESCRIPTION
Fix: `PHP Deprecated:  Creation of dynamic property Palasthotel\FutureMonitor\DashboardWidget::$plugin is deprecated` for PHP 8.2 and beyond.